### PR TITLE
bug inside the binary search in HashRing

### DIFF
--- a/src/main/scala/com/redis/HashRing.scala
+++ b/src/main/scala/com/redis/HashRing.scala
@@ -10,52 +10,52 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.Map
 
 trait HashRing {
-  
+
   val replicas: Int
-  
+
   var sortedKeys: List[Long] = List()
   var cluster = new ArrayBuffer[Redis]
   val ring = Map[Long, Redis]()
-  
+
   // Adds the node to the hashRing
   // including a number of replicas.
   def addNode(node: Redis) = {
     cluster += node
-    (1 to replicas).foreach{ replica => 
+    (1 to replicas).foreach{ replica =>
       val key = calculateChecksum(node+":"+replica)
       ring += (key -> node)
       sortedKeys = sortedKeys ::: List(key)
     }
     sortedKeys = sortedKeys.sortWith(_ < _)
   }
-  
+
   // get the node in the hash ring for this key
   def getNode(key: String) = getNodePos(key)._1
-  
+
   def getNodePos(key: String): (Redis, Int) = {
     val crc = calculateChecksum(key)
     val idx = binarySearch(crc)
     (ring(sortedKeys(idx)), idx)
   }
-  
+
   // TODO this should perform a Bynary search
   def binarySearch(value: Long): Int = {
     var upper = (sortedKeys.length -1)
     var lower = 0
     var idx   = 0
     var comp: Long = 0
-    
+
     while(lower <= upper){
       idx = (lower + upper) / 2
       comp = sortedKeys(idx)
-      
+
       if(comp == value) { return idx }
-      if(comp < value)  { upper = idx -1 }
-      if(comp > value)  { lower = idx +1 }
+      if(comp < value)  { upper = idx - 1 }
+      if(comp > value)  { lower = idx + 1 }
     }
-    return upper
+    return (upper + sortedKeys.length) % sortedKeys.length
   }
-  
+
   // Computes the CRC-32 of the given String
   def calculateChecksum(value: String): Long = {
     val checksum = new CRC32


### PR DESCRIPTION
When hashkey falls below the smallest value, binary search returns -1.  Here is how you repro it:

scala> import com.redis._  
import com.redis._

scala> val host1 = "localhost:6379"  
host1: java.lang.String = localhost:6379

scala> val host2 = "localhost:6380"  
host2: java.lang.String = localhost:6380

scala> val cluster = new RedisCluster(host1, host2)
cluster: com.redis.RedisCluster = localhost:6379 connected:true, localhost:6380 connected:true

scala> cluster.set("x", "x")  
java.lang.IndexOutOfBoundsException
        at scala.collection.LinearSeqOptimized$class.apply(LinearSeqOptimized.scala:53)
        at scala.collection.immutable.List.apply(List.scala:45)
        at com.redis.HashRing$class.getNodePos(HashRing.scala:38)
        at com.redis.RedisCluster.getNodePos(RedisCluster.scala:12)
        at com.redis.HashRing$class.getNode(HashRing.scala:33)
        at com.redis.RedisCluster.getNode(RedisCluster.scala:12)
        at com.redis.RedisCluster.getConnection(RedisCluster.scala:21)
        at com.redis.operations.Operations$class.setKey(Operations.scala:23)
        at com.redis.RedisCluster.setKey(RedisCluster.scala:12)
        at com.redis.operations.Operations$class.set(Operations.scala:17)
        at com.redis.RedisCluster.set(RedisCluster.scala:12)
        at .<init>(<console>:12)
        at .<clinit>(<console>)
        at RequestResult$.<init>(...
scala> 
