### PR TITLE
allow None responses in list replies

### DIFF
--- a/src/main/scala/com/redis/Operations/ListOperations.scala
+++ b/src/main/scala/com/redis/Operations/ListOperations.scala
@@ -72,7 +72,7 @@ trait ListOperations{
   // LRANGE
   // return the specified elements of the list stored at the specified key.
   // Start and end are zero-based indexes. 0 is the first element of the list (the list head), 1 the next element and so on.
-  def listRange(key: String, start: Int, end: Int): Option[List[String]] = {
+  def listRange(key: String, start: Int, end: Int): Option[List[Option[String]]] = {
     val connection = getConnection(key)
     connection.write("LRANGE "+key+" "+start+" "+end+"\r\n")
     connection.readList

--- a/src/main/scala/com/redis/Operations/SortOperations.scala
+++ b/src/main/scala/com/redis/Operations/SortOperations.scala
@@ -13,12 +13,12 @@ trait SortOperations{
   
   // SORT
   // Sort a Set or a List accordingly to the specified parameters.
-  def sort(args: Any): Option[List[String]] = args match {
+  def sort(args: Any): Option[List[Option[String]]] = args match {
     case (key: String, command: String) => doSort(key, command)
     case (key: String) => doSort(key, "")
   }
   
-  def doSort(key: String, command: String): Option[List[String]] = {
+  def doSort(key: String, command: String): Option[List[Option[String]]] = {
     val connection = getConnection(key)
     if(command != "") {
       connection.write("SORT "+key+" "+command+"\r\n")

--- a/src/main/scala/com/redis/SocketOperations.scala
+++ b/src/main/scala/com/redis/SocketOperations.scala
@@ -85,7 +85,7 @@ trait SocketOperations {
       case _  => false
     }
   }
-  def readList: Option[List[String]] = {
+  def readList: Option[List[Option[String]]] = {
     readResponse match {
       case Some(s: String) => listReply(s)
       case _ => None
@@ -163,15 +163,12 @@ trait SocketOperations {
     }
   }
 
-  def listReply(response: String): Option[List[String]] = {
+  def listReply(response: String): Option[List[Option[String]]] = {
     val total = Integer.parseInt(response.split('*')(1))
     if(total != -1) {
-      var list: List[String] = List()
-      (1 to total).foreach { i => 
-        bulkReply(readtype._2) match {
-          case Some(s) => list = (list ::: List(s))
-          case _ => None
-        }
+      var list: List[Option[String]] = List()
+      (1 to total).foreach { i =>
+        list = list ::: List(bulkReply(readtype._2))
       }
       Some(list)
     } else {

--- a/src/test/scala/com/redis/operations/ListOperationsSpec.scala
+++ b/src/test/scala/com/redis/operations/ListOperationsSpec.scala
@@ -60,7 +60,7 @@ object ListOperationsSpec extends Specification with Mockito {
     }
     
     "return list range" in {
-      val listResult = Some(List("one", "two", "three", "four", "five"))
+      val listResult = Some(List("one", "two", "three", "four", "five").map(Some(_)))
       connection.readList returns listResult
       client.listRange("k", 2, 4) mustEqual listResult
       connection.write("LRANGE k 2 4\r\n") was called

--- a/src/test/scala/com/redis/operations/NodeOperationsSpec.scala
+++ b/src/test/scala/com/redis/operations/NodeOperationsSpec.scala
@@ -30,7 +30,7 @@ object NodeOperationsSpec extends Specification with Mockito {
     }
     
     "return all specified keys" in {
-      val list = Some(List[String]("hola", null, null))
+      val list = Some(List[Option[String]](Some("hola"), None, None))
       connection.readList returns list
       client.mget("a", "b", "c") mustEqual list
       connection.write("MGET a b c\r\n") was called

--- a/src/test/scala/com/redis/operations/SortOperationsSpec.scala
+++ b/src/test/scala/com/redis/operations/SortOperationsSpec.scala
@@ -18,14 +18,14 @@ object SortOperationsSpec extends Specification with Mockito {
     }
     
     "sort the contents of the specified key" in {
-      val listResult = Some(List("one", "two", "three"))
+      val listResult = Some(List("one", "two", "three").map(Some(_)))
       connection.readList returns listResult
       client.sort("set", "ALPHA DESC") mustEqual listResult
       connection.write("SORT set ALPHA DESC\r\n") was called
     }
     
     "sort the contents of the specified key with default" in {
-      val listResult = Some(List("one", "two", "three"))
+      val listResult = Some(List("one", "two", "three").map(Some(_)))
       connection.readList returns listResult
       client.sort("set") mustEqual listResult
       connection.write("SORT set\r\n") was called


### PR DESCRIPTION
Hello,

Currently, if you use mget and some of the keys are unset, the returned list removes those values, so you don't know which keys the values correspond to. E.g.
  mget("a", "b", "c") => (1, 5) 

This patch change turns the response to:
  mget("a", "b", "c") => (1, None, 5)

It involves changing the type signature of the mget and sort API calls from Option[List[String]] to Option[List[Option[String]]].
