### PR TITLE
fix mget

### DIFF
--- a/src/main/scala/com/redis/Operations/NodeOperations.scala
+++ b/src/main/scala/com/redis/Operations/NodeOperations.scala
@@ -43,7 +43,7 @@ trait NodeOperations {
   // MGET (key, key, key, ...)
   // get the values of all the specified keys.
   def mget(keys: String*) = {
-    connection.write("MGET "+keys.mkString(" ")+"\r\n")
+    connection.writeMultiBulk(keys.size, "MGET", keys)
     connection.readList
   }
   

--- a/src/main/scala/com/redis/SocketOperations.scala
+++ b/src/main/scala/com/redis/SocketOperations.scala
@@ -211,6 +211,10 @@ trait SocketOperations {
   def writeMultiBulk(size: Int, command: String, arguments: Map[String, String]) = {
     write("*"+ (size+1) +"\r\n"+ bulkFormat(command) + mapToMultiBulkFormat(arguments))
   }
+
+  def writeMultiBulk(size: Int, command: String, arguments: Seq[String]) = {
+    write("*"+ (size+1) +"\r\n"+ bulkFormat(command) + arguments.map(bulkFormat(_)).mkString)
+  }
   
   def bulkFormat(value: String): String = "$"+ value.length+"\r\n"+ value +"\r\n"
   


### PR DESCRIPTION
Use the multibulk syntax when making mget requests. Otherwise, keys with spaces in them get interpreted as multiple keys.
